### PR TITLE
Updated with changes made by Sloc2003

### DIFF
--- a/BootyTester
+++ b/BootyTester
@@ -7,8 +7,6 @@ f:SetScript("OnEvent", function(self,event,unit)
  	for items = 1, 17, 1 do
  		--local slotter = GetInventoryItemID("target",items)
  		local itemName, _, _, itemLevel = GetItemInfo(GetInventoryItemID("target", items))
- 		if itemName == nil then break
- 		end
  		print("" .. itemName .." is level " .. itemLevel)
  	end
  end

--- a/BootyTester
+++ b/BootyTester
@@ -1,0 +1,18 @@
+local myinspectunit
+local f = CreateFrame("Frame")
+
+f:SetScript("OnEvent", function(self,event,unit)
+ if unit == myinspectunit then
+ f:UnregisterEvent("INSPECT_READY")
+ local primary_talent_tab_id = GetPrimaryTalentTree(true)
+ _, primary_talent = GetTalentTabInfo(primary_talent_tab_id, true)
+ print(UnitName("target").."'s primary talent: "..primary_talent)
+ end
+ end)
+
+SLASH_INSPECTTEST1 = "/it"
+SlashCmdList["INSPECTTEST"] = function()
+ myinspectunit = UnitGUID("target")
+ NotifyInspect("target")
+ f:RegisterEvent("INSPECT_READY")
+ end

--- a/BootyTester
+++ b/BootyTester
@@ -1,18 +1,22 @@
 local myinspectunit
-local f = CreateFrame("Frame")
+local f = CreateFrame("Frame",nil, nil)
 
 f:SetScript("OnEvent", function(self,event,unit)
  if unit == myinspectunit then
- f:UnregisterEvent("INSPECT_READY")
- local primary_talent_tab_id = GetPrimaryTalentTree(true)
- _, primary_talent = GetTalentTabInfo(primary_talent_tab_id, true)
- print(UnitName("target").."'s primary talent: "..primary_talent)
+ 	f:UnregisterEvent("INSPECT_READY")
+ 	for items = 1, 17, 1 do
+ 		--local slotter = GetInventoryItemID("target",items)
+ 		local itemName, _, _, itemLevel = GetItemInfo(GetInventoryItemID("target", items))
+ 		if itemName == nil then break
+ 		end
+ 		print("" .. itemName .." is level " .. itemLevel)
+ 	end
  end
- end)
+end)
 
-SLASH_INSPECTTEST1 = "/it"
-SlashCmdList["INSPECTTEST"] = function()
+SLASH_BOOTYTEST1 = "/booty"
+SlashCmdList["BOOTYTEST"] = function()
  myinspectunit = UnitGUID("target")
  NotifyInspect("target")
  f:RegisterEvent("INSPECT_READY")
- end
+end

--- a/BootyTester
+++ b/BootyTester
@@ -5,7 +5,10 @@ f:SetScript("OnEvent", function(self,event,unit)
  if unit == myinspectunit then
  	f:UnregisterEvent("INSPECT_READY")
  	for items = 1, 17, 1 do
+ 	
+ 		--this was an extra step between GetInventoryItemID and GetItem Info.
  		--local slotter = GetInventoryItemID("target",items)
+ 		
  		local itemName, _, _, itemLevel = GetItemInfo(GetInventoryItemID("target", items))
  		print("" .. itemName .." is level " .. itemLevel)
  	end

--- a/BootyTester.toc
+++ b/BootyTester.toc
@@ -1,0 +1,6 @@
+## Interface: 60000
+## Title: BootyTester
+## Author: Ökko and DominoAfekt
+## Version
+## Notes: This thing is going to rock!
+BootyTester.lua


### PR DESCRIPTION
Currently works when targeting the player, but there are still issues:
* Returns base item info.  ie if equipped item is warforged it will not show in GetItemInfo.  Also will return transmog info instead of actual item equipped if the item is transmogged.
* GetItemInfo(GetInventoryItemID()) is not looping properly when inspecting other players.  Run once, run a check to make sure it was cached, if it wasn't run it again before printing.  This might fix it
